### PR TITLE
fix(standalone tests): length-prefix deframing + concurrent I/O for large (re-chunked) messages

### DIFF
--- a/nm_standalone_test.js
+++ b/nm_standalone_test.js
@@ -17,8 +17,6 @@ const command = new Deno.Command(path, {
 console.log(`\u001b[32mTesting ${path} Native Messaging host\u001b[0m\r\n`);
 
 const subprocess = command.spawn();
-const buffer = new ArrayBuffer(0, { maxByteLength: (1024 ** 2 * 64) });
-const view = new DataView(buffer);
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 
@@ -45,38 +43,45 @@ async function sendMessage(input, data = encodeMessage("\r\n\r\n")) {
   }
 }
 
+// Length-prefix deframer. A single OS read can straddle a frame boundary
+// (tail of frame N + the 4-byte header of frame N+1), so we must read EXACTLY
+// the declared number of bytes and carry any remainder to the next frame —
+// never accumulate past `messageLength`, or JSON.parse sees the next header
+// after `...]` and throws ("non-whitespace after JSON at position <len>").
 async function* getMessage(readable) {
-  let messageLength = 0;
-  let readOffset = 0;
-  for await (let message of readable) {
-    if (buffer.byteLength === 0 && messageLength === 0) {
-      buffer.resize(4);
-      for (let i = 0; i < 4; i++) {
-        view.setUint8(i, message[i]);
-      }
-      messageLength = view.getUint32(0, true);
-      if (messageLength === 0) {
-        break;
-      }
-      console.log({ messageLength });
+  const iterator = readable[Symbol.asyncIterator]();
+  let carry = new Uint8Array(0); // bytes already read that belong to a later frame
 
-      message = message.subarray(4);
-      buffer.resize(0);
+  // Resolve exactly `n` bytes from carry first, then the stream.
+  async function readExactly(n) {
+    while (carry.length < n) {
+      const { value, done } = await iterator.next();
+      if (done) return null;
+      const merged = new Uint8Array(carry.length + value.length);
+      merged.set(carry, 0);
+      merged.set(value, carry.length);
+      carry = merged;
     }
-    if (message.length) {
-      buffer.resize(buffer.byteLength + message.length);
-      for (let i = 0; i < message.length; i++, readOffset++) {
-        view.setUint8(readOffset, message[i]);
-      }
+    const out = carry.subarray(0, n);
+    carry = carry.subarray(n);
+    return out;
+  }
 
-      if (buffer.byteLength >= messageLength) {
-        console.log(buffer.byteLength, messageLength);
-        yield new Uint8Array(buffer);
-        messageLength = 0;
-        readOffset = 0;
-        buffer.resize(0);
-      }
-    }
+  for (;;) {
+    const header = await readExactly(4);
+    if (header === null) break;
+    const messageLength = new DataView(
+      header.buffer,
+      header.byteOffset,
+      4,
+    ).getUint32(0, true);
+    if (messageLength === 0) break;
+    console.log({ messageLength });
+
+    const body = await readExactly(messageLength);
+    if (body === null) break;
+    console.log(body.length, messageLength);
+    yield body;
   }
 }
 
@@ -84,7 +89,7 @@ let controller = void 0;
 
 const readable = new ReadableStream({
   start(c) {
-    return controller = c;
+    return (controller = c);
   },
 });
 
@@ -130,16 +135,14 @@ async function echoNativeMessage(input) {
 })();
 
 try {
-  for (
-    const message of [   
-      Array(209715),
-      "test",
-      "",
-      1,
-      new Uint8Array([97]),
-      Array(209715 * 64),
-    ]
-  ) {
+  for (const message of [
+    Array(209715),
+    "test",
+    "",
+    1,
+    new Uint8Array([97]),
+    Array(209715 * 64),
+  ]) {
     await echoNativeMessage(message);
   }
   controller.close();

--- a/nm_standalone_test_node.js
+++ b/nm_standalone_test_node.js
@@ -20,47 +20,49 @@ function encodeMessage(message) {
   return encoder.encode(JSON.stringify(message));
 }
 
-async function readNativeMessage() {
-  const buffer = new ArrayBuffer(0, {
-    maxByteLength: 1024 ** 2 * 64,
-  });
-  const { resolve, promise } = Promise.withResolvers();
-  let bytesRead = 0;
-  let offset = 0;
-  let messageLength = 0;
-  function read() {
-    if (messageLength === 0) {
-      const header = new Uint8Array(4);
-      const headerBuffer = subprocess.stdout.read(4);
-      header.set(headerBuffer, 0);
-      messageLength = header[0] + header[1] * 256 + header[2] * 65536 +
-        header[3] * 16777216;
-      console.log({ messageLength });
+// Persistent flowing reader + length-prefix deframer. ONE 'data' handler is
+// attached up front (not per-call), so stdout always drains concurrently with
+// stdin writes. Paused-mode `read(n)` stalls when n exceeds the stream's
+// highWaterMark (a re-chunk frame is ~1 MiB), and a reader attached only after
+// the write deadlocks large inputs — both avoided here. Frames are buffered and
+// clipped to exactly the declared length, so a read that straddles a frame
+// boundary never bleeds the next header into the current body.
+let stdoutBuffer = Buffer.alloc(0);
+let frameNeed = -1; // -1 = awaiting 4-byte header; >= 0 = awaiting that many body bytes
+const frameQueue = []; // parsed frames not yet consumed by a reader
+const frameWaiters = []; // pending readNativeMessage() resolvers
+
+subprocess.stdout.on("data", (chunk) => {
+  stdoutBuffer = Buffer.concat([stdoutBuffer, chunk]);
+  while (true) {
+    if (frameNeed < 0) {
+      if (stdoutBuffer.length < 4) break;
+      frameNeed = stdoutBuffer.readUInt32LE(0);
+      stdoutBuffer = stdoutBuffer.subarray(4);
+      console.log({ messageLength: frameNeed });
     }
-    while (messageLength > 0 && bytesRead < messageLength) {
-      const data = subprocess.stdout.read(messageLength);
-      if (data === null) {
-        break;
-      }
-      bytesRead += data.length;
-      buffer.resize(buffer.byteLength + data.length);
-      new Uint8Array(buffer, offset).set(data);
-      offset += data.length;
-      if (bytesRead === messageLength) {
-        subprocess.stdout.removeListener("readable", read);
-        const json = JSON.parse(decoder.decode(new Uint8Array(buffer)));
-        resolve(json);
-        buffer.resize(0);
-        bytesRead = 0;
-        offset = 0;
-        messageLength = 0;
-        break;
-      }
+    if (stdoutBuffer.length < frameNeed) break; // wait for the full frame body
+    const body = stdoutBuffer.subarray(0, frameNeed);
+    stdoutBuffer = stdoutBuffer.subarray(frameNeed);
+    frameNeed = -1;
+    const json = JSON.parse(decoder.decode(body));
+    if (frameWaiters.length > 0) {
+      frameWaiters.shift()(json);
+    } else {
+      frameQueue.push(json);
     }
   }
+});
 
-  subprocess.stdout.on("readable", read);
-  return promise;
+subprocess.stdout.on("end", () => {
+  while (frameWaiters.length > 0) frameWaiters.shift()(null);
+});
+
+function readNativeMessage() {
+  if (frameQueue.length > 0) {
+    return Promise.resolve(frameQueue.shift());
+  }
+  return new Promise((resolve) => frameWaiters.push(resolve));
 }
 
 async function echoNativeMessage(input) {
@@ -69,19 +71,25 @@ async function echoNativeMessage(input) {
   const inputLength = input.length;
   const header = new Uint8Array([
     messageLength & 255,
-    messageLength >> 8 & 255,
-    messageLength >> 16 & 255,
-    messageLength >> 24 & 255,
+    (messageLength >> 8) & 255,
+    (messageLength >> 16) & 255,
+    (messageLength >> 24) & 255,
   ]);
   const data = new Uint8Array(header.length + messageLength);
   let outputLength = 0;
   data.set(header, 0);
   data.set(message, 4);
+  // Attach the stdout reader BEFORE writing stdin so output drains
+  // concurrently. Otherwise large inputs deadlock: the host interleaves stdin
+  // reads and stdout writes; once the 64 KB stdout pipe fills, the host blocks
+  // on write and stops draining stdin, so 'drain' never fires and the reader is
+  // never attached.
+  let pending = readNativeMessage();
   if (!subprocess.stdin.write(data)) {
     await new Promise((resolve) => subprocess.stdin.once("drain", resolve));
   }
   while (true) {
-    const result = await readNativeMessage();
+    const result = await pending;
     if (result === null) {
       break;
     }
@@ -91,6 +99,7 @@ async function echoNativeMessage(input) {
       if (outputLength === inputLength) {
         return { inputLength, outputLength };
       }
+      pending = readNativeMessage();
     } else {
       outputLength = JSON.stringify(result).length;
       return { inputLength: JSON.stringify(input).length, outputLength };
@@ -99,16 +108,14 @@ async function echoNativeMessage(input) {
 }
 
 try {
-  for (
-    const message of [
-      Array(209715),
-      "test",
-      "",
-      1,
-      new Uint8Array([97]),
-      Array(209715 * 64),
-    ]
-  ) {
+  for (const message of [
+    Array(209715),
+    "test",
+    "",
+    1,
+    new Uint8Array([97]),
+    Array(209715 * 64),
+  ]) {
     const result = await echoNativeMessage(message);
     console.log(result);
   }


### PR DESCRIPTION
Both standalone test harnesses failed on large messages that a host re-chunks into multiple ≤1 MiB frames (surfaced while testing a js2wasm-compiled host in loopdive/js2#389, but the bugs are host-agnostic — any host that re-chunks triggers them).

**`nm_standalone_test.js` (Deno).** `getMessage()` grew a buffer by each OS read and yielded when `byteLength >= messageLength`, so a read straddling a frame boundary pulled the next frame's 4-byte header into the body → `JSON.parse` threw `Unexpected non-whitespace character after JSON at position <len>` (`1048571` in the repro). Replaced with a length-prefix state machine that reads **exactly** the declared bytes and carries any remainder to the next frame.

**`nm_standalone_test_node.js` (Node).** The stdout reader was attached only *after* writing stdin, and used paused-mode `read(n)` with `n` ≈ 1 MiB (> highWaterMark). Large inputs deadlocked (host blocks on stdout → stops draining stdin → `'drain'` never fires) and `read(n)` stalled. Replaced with a persistent flowing `'data'` reader + length-prefix buffer attached up front; the reader is started **before** the stdin write so stdout drains concurrently.

**Verified:** both now round-trip the 64 MiB `Array(209715 * 64)` case — exit 0, `inputLength === outputLength === 13421760`. Smaller messages unchanged.
